### PR TITLE
Update telegram_match_poster.py

### DIFF
--- a/telegram_match_poster.py
+++ b/telegram_match_poster.py
@@ -1,6 +1,7 @@
 import requests
 import json
 from datetime import datetime, timedelta
+from pytz import timezone
 import time
 import random
 import logging
@@ -281,12 +282,12 @@ def main():
     }
 
     # Get yesterday's date
-    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    yesterday = (datetime.now(timezone('Africa/Nairobi')) - timedelta(days=1)).strftime("%Y-%m-%d")
     yesterday_matches = filter_matches_by_date(json_data, yesterday)
     congrats_message = check_yesterday_results(yesterday_matches)
 
     # Get today's matches
-    todays_matches = filter_matches_by_date(json_data, datetime.now().strftime("%Y-%m-%d"))
+    todays_matches = filter_matches_by_date(json_data, datetime.now(timezone('Africa/Nairobi')).strftime("%Y-%m-%d"))
     
     message_parts = []
     if congrats_message:


### PR DESCRIPTION
This pull request updates the `telegram_match_poster.py` script to handle time zones explicitly by using the `pytz` library. The most important changes include importing the `timezone` function from `pytz` and modifying date-related logic to use the `Africa/Nairobi` time zone.

### Time zone handling updates:
* [`telegram_match_poster.py`](diffhunk://#diff-13b376a2b09a42cddcaa5d1179f1ef49243496d471ac22a8b43b47a5c49e2747R4): Added an import for the `timezone` function from the `pytz` library to support time zone-specific operations.
* [`telegram_match_poster.py`](diffhunk://#diff-13b376a2b09a42cddcaa5d1179f1ef49243496d471ac22a8b43b47a5c49e2747L284-R290): Updated the `yesterday` and `todays_matches` date calculations in the `main()` function to use the `Africa/Nairobi` time zone, ensuring accurate date filtering based on the local time zone.